### PR TITLE
added environment variable to generate dhparam and then exit the cont…

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -66,6 +66,11 @@ else
   echo "+-- dhparam found in $DHPARAM_FILE"
 fi
 
+if [ "$NGINX_BOOT" = "false" ]; then
+  echo "NGINX_BOOT is set to false, exiting."
+  exit
+fi
+
 # start the watch
 watch_logfiles &
 sleep 1


### PR DESCRIPTION
…ainer

This allows the container to create the dhparam file and then exit. It's useful for setup scripts where generating the dhparam on low-resource machines will cause other containers to error out with too little memory available instead of booting when coming up the first time.
