### PR TITLE
Update NGINX Version and Key

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
 RUN case $NGINX_PACKAGE in \
     nginx) \
         echo "+-- building with nginx.org package: ${NGINX_PACKAGE}"; \
-        apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0xABF5BD827BD9BF62 && \
+        apt-key adv --keyserver keyserver.ubuntu.com --recv-keys ABF5BD827BD9BF62 && \
         echo "deb http://nginx.org/packages/mainline/debian `lsb_release -cs` nginx" >> /etc/apt/sources.list; \
         ;; \
     nginx-light|nginx-full|nginx-extras) \

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
 RUN case $NGINX_PACKAGE in \
     nginx) \
         echo "+-- building with nginx.org package: ${NGINX_PACKAGE}"; \
-        apt-key adv --keyserver keyserver.ubuntu.com --recv-keys ABF5BD827BD9BF62 && \
+        apt-key adv --no-tty --keyserver keyserver.ubuntu.com --recv-keys ABF5BD827BD9BF62 && \
         echo "deb http://nginx.org/packages/mainline/debian `lsb_release -cs` nginx" >> /etc/apt/sources.list; \
         ;; \
     nginx-light|nginx-full|nginx-extras) \

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
 RUN case $NGINX_PACKAGE in \
     nginx) \
         echo "+-- building with nginx.org package: ${NGINX_PACKAGE}"; \
-        apt-key adv --keyserver pgp.mit.edu --recv-keys ABF5BD827BD9BF62 && \
+        apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0xABF5BD827BD9BF62 && \
         echo "deb http://nginx.org/packages/mainline/debian `lsb_release -cs` nginx" >> /etc/apt/sources.list; \
         ;; \
     nginx-light|nginx-full|nginx-extras) \

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,10 +43,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
 RUN case $NGINX_PACKAGE in \
     nginx) \
         echo "+-- building with nginx.org package: ${NGINX_PACKAGE}"; \
-        curl -fsSL https://nginx.org/keys/nginx_signing.key | apt-key add -; \
-        apt-key fingerprint ABF5BD827BD9BF62; \
+        apt-key adv --keyserver pgp.mit.edu --recv-keys ABF5BD827BD9BF62 && \
         echo "deb http://nginx.org/packages/mainline/debian `lsb_release -cs` nginx" >> /etc/apt/sources.list; \
-        tee /etc/apt/sources.list.d/nginx.list; \
         ;; \
     nginx-light|nginx-full|nginx-extras) \
         echo "+-- building with Debian-provided package: ${NGINX_PACKAGE}"; \
@@ -59,7 +57,6 @@ RUN case $NGINX_PACKAGE in \
     esac
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-    apt-cache policy nginx && \
     apt-get install -y "${NGINX_PACKAGE}"="${NGINX_VERSION}" && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,19 +32,21 @@ ARG NGINX_PACKAGE=nginx
 
 # NOTICE: Debian-provided packages are *older*, so adjust NGINX_VERSION accordingly
 #         (as of this writing Debian stretch package version is at 1.10*)
-ARG NGINX_VERSION=1.13*
+ARG NGINX_VERSION=1.15*
 
 # requirements
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-    apt-get install -y ca-certificates inotify-tools gnupg2 && \
+    apt-get install -y ca-certificates inotify-tools gnupg2 lsb-release curl && \
     rm -rf /var/lib/apt/lists/*
 
 # reality check
 RUN case $NGINX_PACKAGE in \
     nginx) \
         echo "+-- building with nginx.org package: ${NGINX_PACKAGE}"; \
-        apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62; \
-        echo "deb http://nginx.org/packages/mainline/debian/ stretch nginx" >> /etc/apt/sources.list; \
+        curl -fsSL https://nginx.org/keys/nginx_signing.key | apt-key add -; \
+        apt-key fingerprint ABF5BD827BD9BF62; \
+        echo "deb http://nginx.org/packages/mainline/debian `lsb_release -cs` nginx" >> /etc/apt/sources.list; \
+        tee /etc/apt/sources.list.d/nginx.list; \
         ;; \
     nginx-light|nginx-full|nginx-extras) \
         echo "+-- building with Debian-provided package: ${NGINX_PACKAGE}"; \
@@ -57,9 +59,10 @@ RUN case $NGINX_PACKAGE in \
     esac
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
+    apt-cache policy nginx && \
     apt-get install -y "${NGINX_PACKAGE}"="${NGINX_VERSION}" && \
     rm -rf /var/lib/apt/lists/*
-    
+
 # we might need to install some packages, but doing this in the entrypoint doesn't make any sense
 ARG INSTALL_PACKAGES
 RUN if [ "$INSTALL_PACKAGES" != "" ]; then \


### PR DESCRIPTION
This pull request updates NGINX to 1.15* as well as replacing the signing key with the new one to remove invalid errors.